### PR TITLE
Prepare redpanda for coproc tests

### DIFF
--- a/ansible/playbooks/install-redpanda-from-local-pack.yml
+++ b/ansible/playbooks/install-redpanda-from-local-pack.yml
@@ -1,0 +1,21 @@
+- name: install redpanda
+  hosts: redpanda
+  vars:
+    deb_path: "{{ lookup('env', 'DEB_PATH') }}"
+    deb_name: "{{ deb_path | basename }}"
+
+  tasks:
+    - name: copy deb
+      copy:
+        src: "{{ deb_path }}"
+        dest: /mnt/vectorized/{{ deb_name }}
+    - name: install deb
+      become_user: root
+      shell: |
+        dpkg --force-confold -i /mnt/vectorized/{{ deb_name }}
+
+    - name: set data dir file perms
+      file:
+        path: /var/lib/redpanda/data
+        owner: redpanda
+        group: redpanda

--- a/ansible/playbooks/provision-node.yml
+++ b/ansible/playbooks/provision-node.yml
@@ -2,7 +2,7 @@
 
 - include: prepare-data-dir.yml
 
-- include: install-redpanda.yml
+- include: install-redpanda-from-local-pack.yml
 
 - include: start-redpanda.yml
 

--- a/ansible/playbooks/start-redpanda.yml
+++ b/ansible/playbooks/start-redpanda.yml
@@ -27,7 +27,8 @@
         address: {{ hostvars[inventory_hostname].private_ip }},
         port: 33145
       }' --format yaml
-      sudo rpk mode production
+      rpk config set redpanda.enable_coproc true
+      sudo rpk mode dev
 
       {% if hostvars[groups['redpanda'][0]].id == hostvars[inventory_hostname].id %}
       sudo rpk config bootstrap \

--- a/templates/hosts_ini.tpl
+++ b/templates/hosts_ini.tpl
@@ -7,8 +7,8 @@ ${ ip } ansible_user=${ ssh_user } ansible_become=True private_ip=${redpanda_pri
 %{ for i, ip in client_public_ips ~}
 ${ ip } ansible_user=${ ssh_user } ansible_become=True private_ip=${client_private_ips[i]} id=${i}
 %{ endfor ~}
-
+i
 %{ if enable_monitoring }
 [monitor]
-${ monitor_public_ip[0] } ansible_user=${ ssh_user } ansible_become=True private_ip=${ monitor_private_ip[0] }
+${ monitor_public_ip } ansible_user=${ ssh_user } ansible_become=True private_ip=${ monitor_private_ip }
 %{ endif }


### PR DESCRIPTION
How to deploy local branch:
Set `DEB_PATH` with path to the redpanda deb package (build redpanda with task rp:build then assemble .deb package with `task rp:build-pkg PKG_FORMATS=deb`; 
usually it is assembled to vbuild/release/clang/dist/debian/redpanda_0.0-dev-0000000_amd64.deb